### PR TITLE
Обернул скрипт в init.d файле в функции

### DIFF
--- a/playbooks/hirkn.yml
+++ b/playbooks/hirkn.yml
@@ -79,7 +79,7 @@
     lineinfile:
       path: /etc/crontabs/root
       create: yes
-      line: "0 4 * * * /etc/init.d/hirkn"
+      line: "0 4 * * * /etc/init.d/hirkn reload"
     when: check_cron.stdout == ""
     
   - name: enable and start crontab

--- a/templates/openwrt-hirkn.j2
+++ b/templates/openwrt-hirkn.j2
@@ -2,99 +2,113 @@
 
 START=99
 
-dir=/tmp/lst
-SUBNET=https://antifilter.download/list/subnet.lst
-IP=https://antifilter.download/list/ip.lst
-COMMUNITY=https://community.antifilter.download/list/community.lst
-DOMAINS=https://community.antifilter.download/list/domains.lst
+script () {
+    dir=/tmp/lst
+    SUBNET=https://antifilter.download/list/subnet.lst
+    IP=https://antifilter.download/list/ip.lst
+    COMMUNITY=https://community.antifilter.download/list/community.lst
+    DOMAINS=https://community.antifilter.download/list/domains.lst
 
 
-{% if download_utility == "curl" %}
-download () {
-    count=0
-    while [ ! -f $dir/$1 ]; do
-    if [ $count -gt 10 ]; then
-        echo Exit
-        exit 1
-    else
-        echo "Try $count"
-        curl -f -z $dir/$1 $2 --output $dir/$1
-        count=$((count+1))
-        sleep 5
-    fi
-    done
+    {% if download_utility == "curl" %}
+    download () {
+        count=0
+        while [ ! -f $dir/$1 ]; do
+        if [ $count -gt 10 ]; then
+            echo Exit
+            exit 1
+        else
+            echo "Try $count"
+            curl -f -z $dir/$1 $2 --output $dir/$1
+            count=$((count+1))
+            sleep 5
+        fi
+        done
+    }
+
+    {% elif download_utility == "wget" %}
+    download () {
+        count=0
+        while [ ! -f $dir/$1 ]; do
+        if [ $count -gt 10 ]; then
+            echo Exit
+            exit 1
+        else
+            echo "Try $count"
+            wget -P $dir $2
+            count=$((count+1))
+            sleep 5
+        fi
+        done
+    }
+    {% endif %}
+
+    mkdir -p $dir
+
+    echo "Run download lists"
+    {% if download_utility == "curl" %}
+
+    {% if list_subnet %}
+    curl -f -z $dir/subnet.lst $SUBNET --output $dir/subnet.lst
+    download subnet.lst $SUBNET
+    {% endif %}
+    {% if list_ip %}
+    curl -f -z $dir/ip.lst $IP --output $dir/ip.lst
+    download ip.lst $IP
+    {% endif %}
+    {% if list_community %}
+    curl -f -z $dir/community.lst $COMMUNITY --output $dir/community.lst
+    download community.lst $COMMUNITY
+    {% endif %}
+    {% if list_domains  and (ansible_distribution_major_version < "22" and dnsmasqfull_version.stdout) or ( ansible_distribution_major_version == "22" and dnsmasqfull_version.stdout >= "2.87") %}
+    curl -f -z $dir/domains.lst $DOMAINS --output $dir/domains.lst
+    download domains.lst $DOMAINS
+    {% endif %}
+
+    {% elif download_utility == "wget" %}
+
+    {% if list_subnet %}
+    rm -f /$dir/subnet.lst && wget -P $dir $SUBNET
+    download subnet.lst $SUBNET
+    {% endif %}
+    {% if list_ip %}
+    rm -f /$dir/ip.lst && wget -P $dir $IP
+    download ip.lst $IP
+    {% endif %}
+    {% if list_community %}
+    rm -f /$dir/community.lst && wget -P $dir $COMMUNITY
+    download community.lst $COMMUNITY
+    {% endif %}
+    {% if list_domains  and (ansible_distribution_major_version < "22" and dnsmasqfull_version.stdout) or ( ansible_distribution_major_version == "22" and dnsmasqfull_version.stdout >= "2.87") %}
+    rm -f /$dir/domains.lst && wget -P $dir $DOMAINS
+    download domains.lst $DOMAINS
+    {% endif %}
+    {% endif %}
+
+    {% if list_domains %}
+    {% if ansible_distribution_major_version == "22" and dnsmasqfull_version.stdout >= "2.87" %}
+    sed "s/.*/nftset=\/&\/4#inet#fw4#vpn_domains/" $dir/domains.lst > /tmp/dnsmasq.d/domains
+
+    {% elif ansible_distribution_major_version < "22" and dnsmasqfull_version.stdout %}
+    sed "s/.*/ipset=\/&\/vpn_domains/" $dir/domains.lst > /tmp/dnsmasq.d/domains
+    {% endif %}
+
+    echo "Dnsmasq restart"
+    /etc/init.d/dnsmasq restart
+    {% endif %}
+
+    echo "Firewall restart"
+    /etc/init.d/firewall restart
 }
 
-{% elif download_utility == "wget" %}
-download () {
-    count=0
-    while [ ! -f $dir/$1 ]; do
-    if [ $count -gt 10 ]; then
-        echo Exit
-        exit 1
-    else
-        echo "Try $count"
-        wget -P $dir $2
-        count=$((count+1))
-        sleep 5
-    fi
-    done
+start () {
+    script
 }
-{% endif %}
 
-mkdir -p $dir
+restart () {
+    script
+}
 
-echo "Run download lists"
-{% if download_utility == "curl" %}
-
-{% if list_subnet %}
-curl -f -z $dir/subnet.lst $SUBNET --output $dir/subnet.lst
-download subnet.lst $SUBNET
-{% endif %}
-{% if list_ip %}
-curl -f -z $dir/ip.lst $IP --output $dir/ip.lst
-download ip.lst $IP
-{% endif %}
-{% if list_community %}
-curl -f -z $dir/community.lst $COMMUNITY --output $dir/community.lst
-download community.lst $COMMUNITY
-{% endif %}
-{% if list_domains  and (ansible_distribution_major_version < "22" and dnsmasqfull_version.stdout) or ( ansible_distribution_major_version == "22" and dnsmasqfull_version.stdout >= "2.87") %}
-curl -f -z $dir/domains.lst $DOMAINS --output $dir/domains.lst
-download domains.lst $DOMAINS
-{% endif %}
-
-{% elif download_utility == "wget" %}
-
-{% if list_subnet %}
-rm -f /$dir/subnet.lst && wget -P $dir $SUBNET
-download subnet.lst $SUBNET
-{% endif %}
-{% if list_ip %}
-rm -f /$dir/ip.lst && wget -P $dir $IP
-download ip.lst $IP
-{% endif %}
-{% if list_community %}
-rm -f /$dir/community.lst && wget -P $dir $COMMUNITY
-download community.lst $COMMUNITY
-{% endif %}
-{% if list_domains  and (ansible_distribution_major_version < "22" and dnsmasqfull_version.stdout) or ( ansible_distribution_major_version == "22" and dnsmasqfull_version.stdout >= "2.87") %}
-rm -f /$dir/domains.lst && wget -P $dir $DOMAINS
-download domains.lst $DOMAINS
-{% endif %}
-{% endif %}
-
-{% if list_domains %}
-{% if ansible_distribution_major_version == "22" and dnsmasqfull_version.stdout >= "2.87" %}
-sed "s/.*/nftset=\/&\/4#inet#fw4#vpn_domains/" $dir/domains.lst > /tmp/dnsmasq.d/domains
-
-{% elif ansible_distribution_major_version < "22" and dnsmasqfull_version.stdout %}
-sed "s/.*/ipset=\/&\/vpn_domains/" $dir/domains.lst > /tmp/dnsmasq.d/domains
-{% endif %}
-
-echo "Dnsmasq restart"
-/etc/init.d/dnsmasq restart
-{% endif %}
-
-echo "Firewall restart"
-/etc/init.d/firewall restart
+reload () {
+    script
+}


### PR DESCRIPTION
Чтобы в веб-морде при попытке получения статуса init.d сервиса интерфейс не уходил в таймаут, обернул скрипт в файле в функции.
 Решает проблему в [Issue 4](https://github.com/itdoginfo/ansible-openwrt-hirkn/issues/4)